### PR TITLE
Fix handling weeks that spans across years

### DIFF
--- a/src/ASBNApp.Frontend/ASBNApp.Frontend.csproj
+++ b/src/ASBNApp.Frontend/ASBNApp.Frontend.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="MudBlazor" Version="7.15.0" />
     <PackageReference Include="PDFsharp" Version="6.1.1" />
+    <PackageReference Include="System.Globalization" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ASBNApp.Frontend/Components/App/EntryRow.razor
+++ b/src/ASBNApp.Frontend/Components/App/EntryRow.razor
@@ -14,7 +14,7 @@
 
         @* Date picker *@
         <MudItem xs="3">
-            <MudDatePicker Label="Date" @bind-Date="date" MinDate="@_minDateValue" MaxDate="@_maxDateValue" />
+            <MudDatePicker Label="Select Date" @bind-Date="date" MinDate="@_minDateValue" MaxDate="@_maxDateValue"/>
         </MudItem>
 
         @* Location selector *@
@@ -40,8 +40,8 @@
         @* Location hours input *@
         <MudItem xs="3">
             <MudStack Row>
-                <MudNumericField @bind-Value="Entry.Hours" Label="Select hours" Min="0" Format="N1" />
-                
+                <MudNumericField @bind-Value="Entry.Hours" Label="Set Hours" Min="0" Format="N1" />
+
                 <MudMenu Icon="@Icons.Material.Filled.MoreVert" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.CenterRight">
                     @if(!string.IsNullOrWhiteSpace(Entry.Note))
                     {
@@ -106,7 +106,6 @@
         }
     }
 
-
     private DateTime _date;
     private DateTime? date 
     { 
@@ -122,7 +121,6 @@
     // Min & max values for the date picker.
     private DateTime? _minDateValue;
     private DateTime? _maxDateValue;
-
 
     protected override void OnInitialized()
     {

--- a/src/ASBNApp.Frontend/Components/App/Views/MainViewWeek.razor
+++ b/src/ASBNApp.Frontend/Components/App/Views/MainViewWeek.razor
@@ -65,7 +65,7 @@
         StateHasChanged();
     }
 
-    // Update the data we have from the data the (dummy) interface implementation returns
+    // Update the data we have from the data then interface implementation returns
     // Will be called on initialization & once SelectedWeek or SelectedYear changes
     public async Task GetDataFromWeekDates()
     {

--- a/src/ASBNApp.Frontend/Components/App/Views/MainViewWeek.razor
+++ b/src/ASBNApp.Frontend/Components/App/Views/MainViewWeek.razor
@@ -45,6 +45,11 @@
     private List<EntryRowModelWithID> rows = new();
     private List<WorkLocationWithID> _workLocationHours = new();
 
+    // Creates DateHandler instance & variables to pass down to child component
+    public int? SelectedWeek { get; set; }
+    public int? SelectedYear { get; set; }
+
+
     protected override void OnInitialized()
     {
         GetWorkLocationHours();
@@ -85,11 +90,6 @@
         // Force update the UI
         StateHasChanged();
     }
-
-
-    // Creates DateHandler instance & variables to pass down to child component
-    public int? SelectedWeek { get; set; }
-    public int? SelectedYear { get; set; }
 
     /// <summary>
     /// Called to be called from child component to delete individual entries.

--- a/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
+++ b/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
@@ -2,7 +2,7 @@
 
 <MudItem>
     <MudStack Row="true" Justify="Justify.Center" >
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" OnClick="SelectPreviousWeek" />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" OnClick=@(() => date = date?.AddDays(-7)) />
 
         <MudStack Row="true" Class="mud-theme-primary rounded-pill ps-5" AlignItems="AlignItems.Center">
             <MudText Typo="Typo.subtitle1" Class="m-0"><b>Selected Week: </b>@SelectedWeek of @SelectedYear</MudText>
@@ -10,7 +10,7 @@
             <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Color="Color.Inherit" OnClick="OpenDatePickerOverlay" />
         </MudStack>
 
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" OnClick="SelectNextWeek" />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" OnClick=@(() => date = date?.AddDays(7)) />
     </MudStack>
 
     <MudOverlay @bind-Visible="isDatePickerOverlayVisible" DarkBackground="true" AutoClose="true">
@@ -39,7 +39,7 @@
     DateHandler dateHandler = new DateHandler();
 
 
-    // Logic related to open and closing the date picker overlay
+    // Logic & variables related to openening and closing the date picker overlay
     private bool isDatePickerOverlayVisible;
     public void OpenDatePickerOverlay()
     {
@@ -50,15 +50,19 @@
     // Making the MudDatePicker work (& updating variables)
     MudDatePicker _picker;
     DateTime? _date;
-    DateTime? date 
+    DateTime? date // TODO: Rename to "firstDateOfAWeek"
     { 
         get => _date;
         set {
-            _date = value;
-            SelectedWeek = dateHandler.GetWeekOfYear((DateTime)value);
-            SelectedYear = ((DateTime)value).Year;
+            // ensure we have the first date of a given week before setting it.
+            int week = dateHandler.GetWeekOfYear((DateTime)value);
+            DateTime dateToSet = dateHandler.GetFirstDateOfWeek(week, ((DateTime)value).Year);
+
+            _date = dateToSet;
             isDatePickerOverlayVisible = false;
 
+            SelectedWeek = dateHandler.GetWeekOfYear(dateToSet);
+            SelectedYear = dateToSet.Year;
             TriggerAllCallbacks(SelectedWeek, SelectedYear);
         }
     }
@@ -79,8 +83,7 @@
     {
         await SelectedWeekChanged.InvokeAsync(week);
         await SelectedYearChanged.InvokeAsync(year);
-        // Callback to the parent component
-        await OnCallback.Invoke();
+        await OnCallback.Invoke(); // Callback to the parent component
     }
 
     public void CancelPicker() {
@@ -91,39 +94,5 @@
     public void SetPickerToCurrentWeek() {
         _picker.CloseAsync();
         date = DateTime.Now;
-    }
-
-    // Updates the week number and the formatted week number for the selector
-    // Take into account that we need to switch from 52 to 1 on week numbers and
-    // to the next/previous year
-    // Also update the binded values
-    public void SelectNextWeek()
-    {
-        if (SelectedWeek == 52)
-        {
-            SelectedWeek = 1;
-            SelectedYear++;
-        }
-        else
-        {
-            SelectedWeek++;
-        }
-
-        TriggerAllCallbacks(SelectedWeek, SelectedYear);
-    }
-
-    public void SelectPreviousWeek()
-    {
-        if (SelectedWeek == 01)
-        {
-            SelectedWeek = 52;
-            SelectedYear--;
-        }
-        else
-        {
-            SelectedWeek--;
-        }
-
-        TriggerAllCallbacks(SelectedWeek, SelectedYear);
     }
 }

--- a/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
+++ b/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
@@ -41,10 +41,13 @@
 
     // Logic & variables related to openening and closing the date picker overlay
     private bool isDatePickerOverlayVisible;
-    public void OpenDatePickerOverlay()
+    public async void OpenDatePickerOverlay()
     {
         isDatePickerOverlayVisible = true;
-        StateHasChanged();
+
+        // Workaround for https://github.com/MudBlazor/MudBlazor/issues/10578
+        await Task.Yield();
+        _picker.GoToDate(firstDateOfAWeek.Value);
     }
 
     // Making the MudDatePicker work (& updating variables)

--- a/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
+++ b/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
@@ -2,7 +2,7 @@
 
 <MudItem>
     <MudStack Row="true" Justify="Justify.Center" >
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" OnClick=@(() => date = date?.AddDays(-7)) />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" OnClick=@(() => firstDateOfAWeek = firstDateOfAWeek?.AddDays(-7)) />
 
         <MudStack Row="true" Class="mud-theme-primary rounded-pill ps-5" AlignItems="AlignItems.Center">
             <MudText Typo="Typo.subtitle1" Class="m-0"><b>Selected Week: </b>@SelectedWeek of @SelectedYear</MudText>
@@ -10,11 +10,11 @@
             <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Color="Color.Inherit" OnClick="OpenDatePickerOverlay" />
         </MudStack>
 
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" OnClick=@(() => date = date?.AddDays(7)) />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" OnClick=@(() => firstDateOfAWeek = firstDateOfAWeek?.AddDays(7)) />
     </MudStack>
 
     <MudOverlay @bind-Visible="isDatePickerOverlayVisible" DarkBackground="true" AutoClose="true">
-        <MudDatePicker @ref="_picker" PickerVariant="PickerVariant.Static" @bind-Date="date" ShowWeekNumbers="true">
+        <MudDatePicker @ref="_picker" PickerVariant="PickerVariant.Static" @bind-Date="firstDateOfAWeek" ShowWeekNumbers="true">
             <PickerActions>
                 <MudButton Class="mr-auto align-self-start" OnClick="@(() => CancelPicker())">Cancel</MudButton>
                 <MudButton Color="Color.Primary" OnClick="@(() => SetPickerToCurrentWeek())">Current week</MudButton>
@@ -50,14 +50,13 @@
     // Making the MudDatePicker work (& updating variables)
     MudDatePicker _picker;
     DateTime? _date;
-    DateTime? date // TODO: Rename to "firstDateOfAWeek"
+    DateTime? firstDateOfAWeek
     { 
         get => _date;
         set {
-            // ensure we have the first date of a given week before setting it.
+            // Ensure we have the first date of a given week before setting it.
             int week = dateHandler.GetWeekOfYear((DateTime)value);
             DateTime dateToSet = dateHandler.GetFirstDateOfWeek(week, ((DateTime)value).Year);
-
             _date = dateToSet;
             isDatePickerOverlayVisible = false;
 
@@ -75,7 +74,7 @@
         SelectedYear = DateTime.Now.Year;
 
         // Set value for the date picker
-        date = dateHandler.GetFirstDateOfWeek((int)SelectedWeek, (int)SelectedYear);
+        firstDateOfAWeek = dateHandler.GetFirstDateOfWeek((int)SelectedWeek, (int)SelectedYear);
     }
 
     // Single place to trigger the callbacks
@@ -93,6 +92,6 @@
 
     public void SetPickerToCurrentWeek() {
         _picker.CloseAsync();
-        date = DateTime.Now;
+        firstDateOfAWeek = DateTime.Now;
     }
 }

--- a/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
+++ b/src/ASBNApp.Frontend/Components/App/WeekSelectorLarge.razor
@@ -1,8 +1,11 @@
 @* Large picker to select the week we want to edit. *@
 
+@using System.Globalization;
+
 <MudItem>
     <MudStack Row="true" Justify="Justify.Center" >
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" OnClick=@(() => firstDateOfAWeek = firstDateOfAWeek?.AddDays(-7)) />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateBefore" Color="Color.Primary" 
+                       OnClick=@(() => firstDateOfAWeek = cal.AddWeeks(firstDateOfAWeek.Value, -1)) />
 
         <MudStack Row="true" Class="mud-theme-primary rounded-pill ps-5" AlignItems="AlignItems.Center">
             <MudText Typo="Typo.subtitle1" Class="m-0"><b>Selected Week: </b>@SelectedWeek of @SelectedYear</MudText>
@@ -10,7 +13,8 @@
             <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Color="Color.Inherit" OnClick="OpenDatePickerOverlay" />
         </MudStack>
 
-        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" OnClick=@(() => firstDateOfAWeek = firstDateOfAWeek?.AddDays(7)) />
+        <MudIconButton Icon="@Icons.Material.Filled.NavigateNext" Color="Color.Primary" 
+                       OnClick=@(() => firstDateOfAWeek = cal.AddWeeks(firstDateOfAWeek.Value, 1)) />
     </MudStack>
 
     <MudOverlay @bind-Visible="isDatePickerOverlayVisible" DarkBackground="true" AutoClose="true">
@@ -51,6 +55,7 @@
     }
 
     // Making the MudDatePicker work (& updating variables)
+    Calendar cal = CultureInfo.InvariantCulture.Calendar;
     MudDatePicker _picker;
     DateTime? _date;
     DateTime? firstDateOfAWeek

--- a/src/ASBNApp.Frontend/Components/Export/PillSelectorWeek.razor
+++ b/src/ASBNApp.Frontend/Components/Export/PillSelectorWeek.razor
@@ -2,11 +2,11 @@
 
 <MudStack Row>
     <MudChipSet T="string" @bind-SelectedValue="_selected" Filter Mandatory>
-        <MudChip Value="@("currentWeek")" Color="Color.Primary" OnClick="@(e => { UpdateFromWeekPicker(0); _selected = "currentWeek"; })">
+        <MudChip Value="@("currentWeek")" Color="Color.Primary" OnClick="@(e => { UpdateFromWeekPicker(); _selected = "currentWeek"; })">
             Current Week (Week @_currentWeek)
         </MudChip>
 
-        <MudChip Value="@("nextWeek")" Color="Color.Primary" OnClick="@(e => { UpdateFromWeekPicker(1); _selected = "nextWeek"; })">
+        <MudChip Value="@("nextWeek")" Color="Color.Primary" OnClick="@(e => { date = date?.AddDays(-7); _selected = "nextWeek"; })">
             Previous Week (Week @(_currentWeek - 1))
         </MudChip>
 
@@ -116,27 +116,12 @@
     }
 
     // Updated SelectedYear & Selected Week from the pill selector
-    public void UpdateFromWeekPicker(int option)
+    public void UpdateFromWeekPicker()
     {
         // this week selected
-        if (option == 0)
-        {
-            SelectedWeek = dateHandler.GetCurrentWeekOfYear();
-            SelectedYear = DateTime.Now.Year;
-        }
-        // previous week selected
-        else
-        {
-            if (SelectedWeek == 1)
-            {
-                SelectedWeek = 52;
-                SelectedYear--;
-            }
-            else
-            {
-                SelectedWeek--;
-            }
-        }
+        SelectedWeek = dateHandler.GetCurrentWeekOfYear();
+        SelectedYear = DateTime.Now.Year;
+
         TriggerAllCallbacks(SelectedWeek, SelectedYear);
     }
 }

--- a/src/ASBNApp.Frontend/Services/DateHandler.cs
+++ b/src/ASBNApp.Frontend/Services/DateHandler.cs
@@ -94,14 +94,6 @@ public class DateHandler {
     /// <returns> DateTime object for the first day in a week </returns>
     public DateTime GetLastDateOfWeek(int week, int year) 
     {
-        //// Get first Monday of a year
-        //DateTime FirstDayOfAYear = new DateTime(year, 1, 1);
-        //DateTime FirstMondayOfAYear = new DateTime(year, 1, (8 - (int)FirstDayOfAYear.DayOfWeek) % 7 + 1);
-
-        //// Calculate how many days we're in from that first Monday by the number of weeks, 
-        //// add 6 days to get the last date in a week
-        //return FirstMondayOfAYear.AddDays((week - 1) * 7 + 6);
-
         return GetFirstDateOfWeek(week, year).AddDays(6);
     }
 

--- a/src/ASBNApp.Frontend/Services/DateHandler.cs
+++ b/src/ASBNApp.Frontend/Services/DateHandler.cs
@@ -64,16 +64,22 @@ public class DateHandler {
     }
 
     /// <summary>
-    /// Returns the Monday date for a given week & year
+    /// Returns the Monday date for a given week & year.
     /// </summary>
     /// <returns> DateTime object for the first day in a week </returns>
-    public DateTime GetFirstDateOfWeek(int week, int year) {
-        // Get first Monday of a year
+    public DateTime GetFirstDateOfWeek(int week, int year)
+    {
         DateTime FirstDayOfAYear = new DateTime(year, 1, 1);
         DateTime FirstMondayOfAYear = new DateTime(year, 1, (8 - (int)FirstDayOfAYear.DayOfWeek) % 7 + 1);
 
-        // Calculate how many days we're in from that first Monday by the number of weeks
-        return FirstMondayOfAYear.AddDays((week - 1) * 7);
+		// Get the weekday of January 1st
+		DayOfWeek dayOfWeek = FirstDayOfAYear.DayOfWeek;
+
+		// Calculate days in the first week (from 01.01 to the first Sunday)
+		int daysInFirstWeek = dayOfWeek == DayOfWeek.Sunday ? 1 : 7 - (int)dayOfWeek + 1;
+
+		// Calculate how many days we're in from that first day by the number of weeks
+		return FirstDayOfAYear.AddDays(((week - 2) * 7) + daysInFirstWeek);
     }
 
     /// <summary>

--- a/src/ASBNApp.Frontend/Services/DateHandler.cs
+++ b/src/ASBNApp.Frontend/Services/DateHandler.cs
@@ -1,17 +1,17 @@
+using System.Globalization;
+
+
 /// <summary>
 /// Week handler to get various information about weeks
 /// </summary>
-
-
-using System.Globalization;
-
 public class DateHandler {
 
     /// <summary>
     /// Function to get the current week number
     /// </summary> 
     /// <returns>Week number as an int</returns>
-    public int GetCurrentWeekOfYear() {
+    public int GetCurrentWeekOfYear() 
+    {
         // get culture info & current date/time from thread
         var CultureInfo = Thread.CurrentThread.CurrentCulture;
         DateTime Date = DateTime.Now;
@@ -25,10 +25,12 @@ public class DateHandler {
     }
 
     /// <summary>
-    /// Calculates the week number for a given date
+    /// Calculates the week number for a given date.
     /// </summary>
-    /// <returns>int representing the week of year for the given date</returns>
-    public int GetWeekOfYear(DateTime date) {
+    /// <param name="date"><see cref="DateTime"/> to calculate the week for.</param>
+    /// <returns><see cref="int"/> representing the week of year for the given date</returns>
+    public int GetWeekOfYear(DateTime date) 
+    {
         // Get calendar for current culture info
         var cultureInfo = Thread.CurrentThread.CurrentCulture;
         Calendar calendar = cultureInfo.Calendar;
@@ -45,7 +47,8 @@ public class DateHandler {
     /// Returns the first day of the current week
     /// </summary>
     /// <returns>Day with day & month as a string</returns>
-    public string GetFirstDayOfWeekAsString() {
+    public string GetFirstDayOfWeekAsString() 
+    {
         // (int)Date.DayOfWeek returns from a 0 for Sunday up to a 6 for Saturday -> + Monday makes the start of the week Monday
         var FirstDay = DateTime.Today.AddDays(-((int)DateTime.Today.DayOfWeek + (int)DayOfWeek.Monday));
         
@@ -56,7 +59,8 @@ public class DateHandler {
     /// Returns the last day of the current week
     /// </summary>
     /// <returns>Date with day & month as a string</returns>
-    public string GetLastDayOfWeekAsString() {
+    public string GetLastDayOfWeekAsString() 
+    {
         // get 7 - DayOfWeek, add result to FirstDayOfWeek
         var LastDay = DateTime.Today.AddDays(7 - (int)DateTime.Today.DayOfWeek);
 
@@ -69,31 +73,36 @@ public class DateHandler {
     /// <returns> DateTime object for the first day in a week </returns>
     public DateTime GetFirstDateOfWeek(int week, int year)
     {
-        DateTime FirstDayOfAYear = new DateTime(year, 1, 1);
-        DateTime FirstMondayOfAYear = new DateTime(year, 1, (8 - (int)FirstDayOfAYear.DayOfWeek) % 7 + 1);
+        CultureInfo ci = CultureInfo.CurrentCulture;
 
-		// Get the weekday of January 1st
-		DayOfWeek dayOfWeek = FirstDayOfAYear.DayOfWeek;
+        DateTime januaryFirst = new DateTime(year, 1, 1);
+        int daysOffset = (int)ci.DateTimeFormat.FirstDayOfWeek - (int)januaryFirst.DayOfWeek;
+        DateTime firstWeekDay = januaryFirst.AddDays(daysOffset);
 
-		// Calculate days in the first week (from 01.01 to the first Sunday)
-		int daysInFirstWeek = dayOfWeek == DayOfWeek.Sunday ? 1 : 7 - (int)dayOfWeek + 1;
+        int firstWeek = ci.Calendar.GetWeekOfYear(januaryFirst, ci.DateTimeFormat.CalendarWeekRule, ci.DateTimeFormat.FirstDayOfWeek);
+        if ((firstWeek <= 1 || firstWeek >= 52) && daysOffset >= -3)
+        {
+            week -= 1;
+        }
 
-		// Calculate how many days we're in from that first day by the number of weeks
-		return FirstDayOfAYear.AddDays(((week - 2) * 7) + daysInFirstWeek);
+        return firstWeekDay.AddDays(week * 7);
     }
 
     /// <summary>
     /// Returns the Sunday date for a given week & year
     /// </summary>
     /// <returns> DateTime object for the first day in a week </returns>
-    public DateTime GetLastDateOfWeek(int week, int year) {
-        // Get first Monday of a year
-        DateTime FirstDayOfAYear = new DateTime(year, 1, 1);
-        DateTime FirstMondayOfAYear = new DateTime(year, 1, (8 - (int)FirstDayOfAYear.DayOfWeek) % 7 + 1);
+    public DateTime GetLastDateOfWeek(int week, int year) 
+    {
+        //// Get first Monday of a year
+        //DateTime FirstDayOfAYear = new DateTime(year, 1, 1);
+        //DateTime FirstMondayOfAYear = new DateTime(year, 1, (8 - (int)FirstDayOfAYear.DayOfWeek) % 7 + 1);
 
-        // Calculate how many days we're in from that first Monday by the number of weeks, 
-        // add 6 days to get the last date in a week
-        return FirstMondayOfAYear.AddDays((week - 1) * 7 + 6);
+        //// Calculate how many days we're in from that first Monday by the number of weeks, 
+        //// add 6 days to get the last date in a week
+        //return FirstMondayOfAYear.AddDays((week - 1) * 7 + 6);
+
+        return GetFirstDateOfWeek(week, year).AddDays(6);
     }
 
     /// <summary>
@@ -109,5 +118,24 @@ public class DateHandler {
 		var diff = today - (DateTime)startDate;
 
 		return (diff.Days / 365) + 1;
+    }
+
+    /// <summary>
+    /// This method is borrowed from http://stackoverflow.com/a/11155102/284240
+    /// 
+    /// It's different from the <see cref="GetWeekOfYear(DateTime)"/> in how it handles the week,
+    /// as the .NET standard allows for weeks to be split across years, which isn't wanted in this case.
+    /// </summary>
+    /// <param name="time"></param>
+    /// <returns></returns>
+    public int GetIso8601WeekOfYear(DateTime time)
+    {
+        DayOfWeek day = CultureInfo.InvariantCulture.Calendar.GetDayOfWeek(time);
+        if (day >= DayOfWeek.Monday && day <= DayOfWeek.Wednesday)
+        {
+            time = time.AddDays(3);
+        }
+
+        return CultureInfo.InvariantCulture.Calendar.GetWeekOfYear(time, CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);
     }
 }

--- a/src/ASBNApp.Frontend/wwwroot/appsettings.json
+++ b/src/ASBNApp.Frontend/wwwroot/appsettings.json
@@ -6,6 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-  //"ApiUrl": "https://localhost:7148",
-  "ApiUrl": "https://asbn.app"
+  "ApiUrl": "https://localhost:7148",
+  //"ApiUrl": "https://asbn.app"
 }

--- a/src/ASBNApp.Frontend/wwwroot/appsettings.json
+++ b/src/ASBNApp.Frontend/wwwroot/appsettings.json
@@ -6,6 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-  "ApiUrl": "https://localhost:7148",
-  //"ApiUrl": "https://asbn.app"
+  //"ApiUrl": "https://localhost:7148",
+  "ApiUrl": "https://asbn.app"
 }


### PR DESCRIPTION
This PR fixes an error that occured when a week spans across two years and if a Sunday is the first day of the week.

Closes #73 