### PR TITLE
Day/week tab switcher hotfix

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,6 +19,8 @@ services:
       dockerfile: src/ASBNApp.DataAPI/Dockerfile
     depends_on:
       - sql-server # Ensures the database starts before the API
+    ports:
+      - "7132:8080"
     environment:
       ConnectionStrings__DatabaseConnection: ${API_CONNECTIONSTRING}
     restart: unless-stopped
@@ -28,7 +30,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: ${DB_SA_PASSWORD} 
+      MSSQL_SA_PASSWORD: ${DB_SA_PASSWORD}
     volumes:
       - sqlData:/var/opt/mssql
     restart: unless-stopped

--- a/src/ASBNApp.DataAPI/ASBNApp.DataAPI.csproj
+++ b/src/ASBNApp.DataAPI/ASBNApp.DataAPI.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>755847cd-79ed-4a5a-8952-2a01d703734a</UserSecretsId>
-		<Version>1.3.3</Version>
+		<Version>1.3.4</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/ASBNApp.Frontend/ASBNApp.Frontend.csproj
+++ b/src/ASBNApp.Frontend/ASBNApp.Frontend.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -7,7 +7,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <UserSecretsId>8dd985a0-e9e4-46d8-939f-a489e18ff0ad</UserSecretsId>
     <OutputType>Exe</OutputType>
-	<Version>1.3.3</Version>
+	<Version>1.3.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ASBNApp.Frontend/Components/Shared/DialogTemplate.razor
+++ b/src/ASBNApp.Frontend/Components/Shared/DialogTemplate.razor
@@ -4,8 +4,9 @@
     </DialogContent>
 
     <DialogActions>
-        <MudButton OnClick="Cancel">Cancel</MudButton>
-        <MudButton Color="@Color" OnClick="Submit">@ButtonText</MudButton>
+        <MudButton Color="@Color" OnClick="Submit" Variant="Variant.Outlined">@ButtonText</MudButton>
+        <MudButton OnClick="Cancel" Variant="Variant.Filled">Cancel</MudButton>
+
     </DialogActions>
 </MudDialog>
 

--- a/src/ASBNApp.Frontend/Components/Shared/Footer.razor
+++ b/src/ASBNApp.Frontend/Components/Shared/Footer.razor
@@ -14,7 +14,8 @@
 	public string GetVersion()
 	{
 		var assembly = Assembly.GetExecutingAssembly();
-		var versionString = assembly.GetName().Version?.ToString() ?? "No version info found.";
-		return versionString;
+		var version = assembly.GetName().Version;
+
+		return version is null ? "No version info found." : $"{version.Major}.{version.Minor}.{version.Build}";
 	}
 }

--- a/src/ASBNApp.Frontend/Pages/App.razor
+++ b/src/ASBNApp.Frontend/Pages/App.razor
@@ -13,12 +13,12 @@
 
     @* Header space *@
     <MudItem>
-        <MudItem Elevation="0" Class="my-10">
+        <MudItem Class="my-10">
             <MudText Typo="Typo.h3" Class="mb-5">Let's see what you've been up to!</MudText>
             <MudText Typo="Typo.subtitle1">What do you wanna log?</MudText>
         </MudItem>
 
-        <MudTabs @ref="_tabs" OnPreviewInteraction="SwitchView">
+        <MudTabs @ref="_tabs" @bind-ActivePanelIndex="_activePanelIndex" OnPreviewInteraction="SwitchView">
             <MudTabPanel Text="Day" Icon="@Icons.Material.Filled.ViewDay" 
                 ToolTip="Single day view, no distraction."  />
 
@@ -27,7 +27,7 @@
         </MudTabs>
     </MudItem>
 
-    <Condition Evaluation="_tabs?.ActivePanelIndex == null || _tabs?.ActivePanelIndex == 0">
+    <Condition Evaluation="_activePanelIndex == 0">
         <Match>
             <MainViewDay />
         </Match>
@@ -39,8 +39,8 @@
 
 
 @code {
-    private bool IsDayBool = true;
     private MudTabs? _tabs;
+    private int _activePanelIndex;
 
     /// <summary>
     /// Called when the user clicks on a tab.
@@ -48,35 +48,32 @@
     /// </summary>
     private async Task SwitchView(TabInteractionEventArgs args)
     {
-        if (args.PanelIndex == 1)
+        if (args.PanelIndex == _activePanelIndex)
         {
-            if (!unsavedContentDialogService.IsDayViewDataSaved)
+            return;
+        }
+
+        if (_activePanelIndex == 0 && !unsavedContentDialogService.IsDayViewDataSaved)
+        {
+            var isDialogCancelled = await OpenConfirmationDialogAsync();
+            if (isDialogCancelled)
             {
-                var isDialogCancelled = await OpenConfirmationDialogAsync();
-                if (isDialogCancelled)
-                {
-                    // Do nothing, stay on the current view
-                    args.Cancel = true;
-                    return;
-                }
+                // Do nothing, stay on the current view
+                args.Cancel = true;
+                return;
             }
         }
 
-        if (args.PanelIndex == 0)
+        if (_activePanelIndex == 1 && !unsavedContentDialogService.IsWeekViewDataSaved)
         {
-            if (!unsavedContentDialogService.IsWeekViewDataSaved)
+            var isDialogCancelled = await OpenConfirmationDialogAsync();
+            if (isDialogCancelled)
             {
-                var isDialogCancelled = await OpenConfirmationDialogAsync();
-                if (isDialogCancelled)
-                {
-                    // Do nothing, stay on the current view
-                    args.Cancel = true;
-                    return;
-                }
+                // Do nothing, stay on the current view
+                args.Cancel = true;
+                return;
             }
         }
-
-        StateHasChanged();
     }
 
     /// <summary>
@@ -91,7 +88,7 @@
             { x => x.ButtonText, "Switch views anyway" },
             { x => x.Color, Color.Error }
         };
-        var options = new DialogOptions { CloseOnEscapeKey = true };
+        var options = new DialogOptions { CloseOnEscapeKey = true, CloseButton = true };
         var dialog = await dialogService.ShowAsync<DialogTemplate>("Unsaved data - continue?", parameters, options);
         var result = await dialog.Result;
         return result.Canceled;

--- a/src/ASBNApp.Frontend/Program.cs
+++ b/src/ASBNApp.Frontend/Program.cs
@@ -50,9 +50,15 @@ builder.Services.AddScoped(
 	sp => (IAccountManagement)sp.GetRequiredService<AuthenticationStateProvider>());
 
 // Configure client for auth/backend interactions
+#if DEBUG
+var uri = new Uri("https://localhost:7148");
+#else
+var uri = new Uri(builder.Configuration["ApiUrl"]);
+#endif
+
 builder.Services.AddHttpClient(
 	"BackendClient",
-	client => client.BaseAddress = new Uri(builder.Configuration["ApiUrl"]))
+	client => client.BaseAddress = uri)
 	.AddHttpMessageHandler<CookieHandler>();
 
 // Configure frontend client

--- a/src/ASBNApp.Frontend/wwwroot/appsettings.json
+++ b/src/ASBNApp.Frontend/wwwroot/appsettings.json
@@ -6,6 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-   "ApiUrl": "https://localhost:7148"
-   //"ApiUrl": "https://asbn.app"
+  "ApiUrl": "https://asbn.app"
 }

--- a/src/ASBNApp.Frontend/wwwroot/appsettings.json
+++ b/src/ASBNApp.Frontend/wwwroot/appsettings.json
@@ -6,6 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-  // "ApiUrl": "https://localhost:7148"
-  "ApiUrl": "https://asbn.app"
+   "ApiUrl": "https://localhost:7148"
+   //"ApiUrl": "https://asbn.app"
 }


### PR DESCRIPTION
This PR includes the following changes:

- **Fixed:** Day/week view tab switcher not changing views
- **Updated:** Docker compose.yaml to expose the api port again
- **Updated:** Version string only shows 3 digits (instead of a fourth, unused one)
- **Updated:** The frontend now uses a set uri as the api url for debugging, for everything else the `ApiUrl` from the frontends `appsettings.json` is used